### PR TITLE
feat:Update OpenAPI Specification for `/videos` Endpoint Response Examples

### DIFF
--- a/src/libs/Forem/openapi.yaml
+++ b/src/libs/Forem/openapi.yaml
@@ -2009,7 +2009,7 @@ paths:
                   cloudinary_video_url: https://dw71fyauz7yz9.cloudfront.net/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f/thumbs-video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f-00001.png
                   title: The Millstone201
                   user_id: 1452
-                  video_duration_in_minutes: '2024-10-10'
+                  video_duration_in_minutes: '2024-10-11'
                   video_source_url: https://dw71fyauz7yz9.cloudfront.net/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f.m3u8
                   user:
                     name: Edgardo "Monroe" \:/ Gusikowski
@@ -2019,7 +2019,7 @@ paths:
                   cloudinary_video_url: https://dw71fyauz7yz9.cloudfront.net/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f/thumbs-video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f-00001.png
                   title: A Many-Splendoured Thing202
                   user_id: 1453
-                  video_duration_in_minutes: '2024-10-10'
+                  video_duration_in_minutes: '2024-10-11'
                   video_source_url: https://dw71fyauz7yz9.cloudfront.net/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f/video-upload__1e42eb0bab4abb3c63baeb5e8bdfe69f.m3u8
                   user:
                     name: Arlena "Catarina" \:/ Zulauf


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the `video_duration_in_minutes` field in the API response examples for video articles.

- **Documentation**
	- Updated OpenAPI specification to ensure accurate representation of video article durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->